### PR TITLE
Add Streamlit Firebase file uploader

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -1,0 +1,21 @@
+import streamlit as st
+
+st.set_page_config(page_title="Firebase Example", page_icon="\U0001F4C2")
+
+st.title("Welcome to the Firebase File Uploader")
+
+st.markdown(
+    """
+    ## Instructions
+    
+    - Use **File Upload** page to upload PDF or text files.
+    - Uploaded files will be stored in Firebase Firestore along with metadata.
+    - A plain text version of the file is also created with the extension `.content`.
+    - Navigate to **File Show** page to list uploaded files, download them or read their text content.
+    
+    Ensure you have added your Firebase service account information to
+    `st.secrets['firebase']` in `.streamlit/secrets.toml` before running this
+    app.
+    """
+)
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Streamlit Firebase Example
+
+This repository contains a simple Streamlit application with multiple pages. The app demonstrates how to upload PDF or text files to Firebase Firestore and view the uploaded files.
+
+## Requirements
+
+- Python 3.9+
+- Streamlit
+- firebase-admin
+- PyPDF2
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the App
+
+Run the Streamlit application from the project root:
+
+```bash
+streamlit run Home.py
+```
+
+Streamlit will automatically detect the additional pages in the `pages/` directory.
+
+## Firebase Setup
+
+Provide your Firebase service account details in `.streamlit/secrets.toml`. The
+credentials should be placed under the `firebase` section:
+
+```toml
+[firebase]
+type = "service_account"
+project_id = "your-project-id"
+private_key_id = "..."
+private_key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+client_email = "..."
+client_id = "..."
+token_uri = "https://oauth2.googleapis.com/token"
+```
+
+Streamlit automatically loads these secrets and the app will use them to
+initialize Firebase.
+

--- a/firebase_app.py
+++ b/firebase_app.py
@@ -1,0 +1,85 @@
+import base64
+from datetime import datetime
+from io import BytesIO
+
+import firebase_admin
+from firebase_admin import credentials, firestore
+import streamlit as st
+from PyPDF2 import PdfReader
+
+
+def init_firestore():
+    """Initialize and return a Firestore client using Streamlit secrets."""
+    if not firebase_admin._apps:
+        cred_info = st.secrets.get("firebase")
+        if cred_info is None:
+            raise RuntimeError("Firebase credentials not found in st.secrets")
+        cred = credentials.Certificate(dict(cred_info))
+        firebase_admin.initialize_app(cred)
+    return firestore.client()
+
+
+def extract_text(file_bytes: bytes, file_type: str) -> str:
+    """Return plain text extracted from PDF or text file bytes."""
+    if file_type == "application/pdf":
+        reader = PdfReader(BytesIO(file_bytes))
+        text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        return text
+    # assume utf-8 text for other types
+    return file_bytes.decode("utf-8", errors="ignore")
+
+
+def upload_file(file_bytes: bytes, filename: str, file_type: str):
+    """Upload the file to Firestore and store metadata."""
+    db = init_firestore()
+    uploaded_at = datetime.utcnow()
+    content_text = extract_text(file_bytes, file_type)
+
+    encoded = base64.b64encode(file_bytes).decode("utf-8")
+
+    # metadata record
+    doc_ref = db.collection("files").document(filename)
+    doc_ref.set({
+        "file_name": filename,
+        "file_size": len(file_bytes),
+        "file_type": file_type,
+        "uploaded_at": uploaded_at,
+        "content_file": f"{filename}.content"
+    })
+
+    # store binary content
+    doc_ref.collection("data").document("binary").set({"content": encoded})
+
+    # second file with plain text
+    db.collection("file_contents").document(f"{filename}.content").set({
+        "text": content_text,
+        "source_file": filename,
+        "uploaded_at": uploaded_at
+    })
+
+
+def list_files():
+    """Return metadata for all uploaded files."""
+    db = init_firestore()
+    docs = db.collection("files").stream()
+    return [doc.to_dict() for doc in docs]
+
+
+def get_file_content(filename: str) -> bytes:
+    """Retrieve binary content for the given filename."""
+    db = init_firestore()
+    doc = db.collection("files").document(filename).collection("data").document("binary").get()
+    if doc.exists:
+        encoded = doc.to_dict().get("content", "")
+        return base64.b64decode(encoded)
+    return b""
+
+
+def get_text_content(filename: str) -> str:
+    """Retrieve text from the .content document."""
+    db = init_firestore()
+    doc = db.collection("file_contents").document(f"{filename}.content").get()
+    if doc.exists:
+        return doc.to_dict().get("text", "")
+    return ""
+

--- a/pages/File_Show.py
+++ b/pages/File_Show.py
@@ -1,0 +1,28 @@
+import streamlit as st
+
+from firebase_app import list_files, get_file_content, get_text_content
+
+st.title("Uploaded Files")
+
+files = list_files()
+
+if not files:
+    st.info("No files uploaded yet.")
+else:
+    for file in files:
+        st.subheader(file["file_name"])
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button(f"Download {file['file_name']}"):
+                data = get_file_content(file["file_name"])
+                st.download_button(
+                    label="Download",
+                    data=data,
+                    file_name=file["file_name"],
+                    mime=file["file_type"],
+                )
+        with col2:
+            if st.button(f"Show text for {file['file_name']}"):
+                text = get_text_content(file["file_name"])
+                st.text_area("File Text", text, height=200)
+

--- a/pages/File_Upload.py
+++ b/pages/File_Upload.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+from firebase_app import upload_file
+
+st.title("Upload a File")
+
+uploaded = st.file_uploader("Choose a PDF or text file", type=["pdf", "txt"])
+
+if uploaded is not None:
+    file_bytes = uploaded.read()
+    file_type = uploaded.type
+    filename = uploaded.name
+
+    if st.button("Upload to Firebase"):
+        try:
+            upload_file(file_bytes, filename, file_type)
+            st.success(f"Uploaded {filename} to Firestore")
+        except Exception as e:
+            st.error(f"Failed to upload: {e}")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+firebase-admin
+PyPDF2
+


### PR DESCRIPTION
## Summary
- add README with setup instructions
- add requirements.txt
- create Firebase helper functions
- implement Streamlit pages: Home, File Upload, File Show
- use Streamlit secrets for Firebase credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685637e00e3883329a15bc5996c0ff89