### PR TITLE
Improve bucket configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,14 @@ private_key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 client_email = "..."
 client_id = "..."
 token_uri = "https://oauth2.googleapis.com/token"
+# Optional: specify a bucket name if different from "<project_id>.appspot.com"
+storage_bucket = "your-custom-bucket-name"
 ```
 
 Streamlit automatically loads these secrets and the app will use them to
 initialize Firebase.
+
+The application expects a Cloud Storage bucket to exist. By default the bucket
+name is assumed to be `<project_id>.appspot.com`. If your bucket uses a
+different name, provide it via the optional `storage_bucket` field shown above.
 

--- a/firebase_app.py
+++ b/firebase_app.py
@@ -14,9 +14,18 @@ def init_firestore():
         if cred_info is None:
             raise RuntimeError("Firebase credentials not found in st.secrets")
         cred = credentials.Certificate(dict(cred_info))
-        firebase_admin.initialize_app(
-            cred, {"storageBucket": cred_info.get("project_id") + ".appspot.com"}
-        )
+
+        # allow overriding the bucket used for uploads
+        bucket_name = cred_info.get("storage_bucket")
+        if not bucket_name:
+            project_id = cred_info.get("project_id")
+            if not project_id:
+                raise RuntimeError(
+                    "project_id or storage_bucket must be provided in st.secrets"
+                )
+            bucket_name = project_id + ".appspot.com"
+
+        firebase_admin.initialize_app(cred, {"storageBucket": bucket_name})
     return firestore.client()
 
 


### PR DESCRIPTION
## Summary
- allow overriding Firebase Storage bucket via `storage_bucket` secret
- document the new option in README

## Testing
- `python -m py_compile Home.py firebase_app.py pages/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856433e076c8332bf4354d1ca04034b