### PR TITLE
Update Firebase docs with new bucket name and setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ private_key = "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 client_email = "..."
 client_id = "..."
 token_uri = "https://oauth2.googleapis.com/token"
-# Optional: specify a bucket name if different from "<project_id>.appspot.com"
+# Optional: specify a bucket name if different from "<project_id>.firebasestorage.app"
 storage_bucket = "your-custom-bucket-name"
 ```
 
@@ -47,6 +47,22 @@ Streamlit automatically loads these secrets and the app will use them to
 initialize Firebase.
 
 The application expects a Cloud Storage bucket to exist. By default the bucket
-name is assumed to be `<project_id>.appspot.com`. If your bucket uses a
+name is assumed to be `<project_id>.firebasestorage.app`. If your bucket uses a
 different name, provide it via the optional `storage_bucket` field shown above.
+
+## Setting up Firebase Storage and Firestore
+
+1. Create a Firebase project at <https://console.firebase.google.com/>.
+2. In the **Firestore Database** section, create a database in production or test mode.
+3. In the **Storage** section, create a Cloud Storage bucket. A bucket named
+   `<project_id>.firebasestorage.app` is normally created automatically when you
+   enable storage.
+
+## Getting the secrets.toml configuration
+
+1. Open your project settings and select **Service accounts**.
+2. Click **Generate new private key** to download a JSON credentials file.
+3. Copy the values from that file into the `[firebase]` section of
+   `.streamlit/secrets.toml` as shown above.
+4. Add a `storage_bucket` entry if your bucket name differs from the default.
 


### PR DESCRIPTION
## Summary
- document that the default bucket is `<project_id>.firebasestorage.app`
- describe how to enable Firebase Storage and Firestore
- explain how to retrieve values for `.streamlit/secrets.toml`

## Testing
- `python -m py_compile Home.py firebase_app.py pages/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856def3002083328a7ae6ee5d5fc872